### PR TITLE
[bug fix] parse out function argument from json

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,4 +1,9 @@
-import { AIConfigRuntime, ExecuteResult, Prompt, OutputDataWithToolCallsValue } from "aiconfig";
+import {
+  AIConfigRuntime,
+  ExecuteResult,
+  Prompt,
+  OutputDataWithToolCallsValue,
+} from "aiconfig";
 import { Chat } from "openai/resources";
 
 const BOOKS_DB = [
@@ -45,13 +50,16 @@ function get(id: string) {
 
 // Use helper function to executes the function specified by the LLM's output for 'function_call'.
 // It handles 'list', 'search', or 'get' functions, and raises an Exception for unknown functions.
-function callFunction(functionCall: string, arg: string) {
+function callFunction(functionCall: string, args: string) {
   switch (functionCall) {
     case "list":
+      var arg = JSON.parse(args).genre;
       return list(arg);
     case "search":
+      var arg = JSON.parse(args).name;
       return search(arg);
     case "get":
+      var arg = JSON.parse(args).id;
       return get(arg);
     default:
       throw new Error(`Unknown function: ${functionCall}`);
@@ -180,10 +188,12 @@ async function main() {
     Array.isArray(completion) ? completion[0] : completion
   ) as ExecuteResult;
 
-  const completionMessage = (output.data as OutputDataWithToolCallsValue);
-  const functionCall = completionMessage.value[0].function
+  const completionMessage = output.data as OutputDataWithToolCallsValue;
+  const functionCall = completionMessage.value[0].function;
 
   const value = callFunction(functionCall!.name, functionCall!.arguments);
+  console.log("Function call result: ", value);
+
   //const value = "test";
   // Use GPT to generate a user-friendly response
   const promptData = {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "aiconfig-function-calling-cookbook",
-  "version": "1.0.0",
-  "main": "function-calling-with-openai.ts",
-  "license": "MIT",
-  "dependencies": {
-      "aiconfig": "^1.0.0"
-  },
-  "devDependencies": {
-      "ts-node": "^10.9.1",
-      "@types/node": "^20.9.0",
-      "typescript": "^5.2.2",
-      "openai": "^4.11.1"
-  }
+    "name": "aiconfig-function-calling-cookbook",
+    "version": "1.0.0",
+    "main": "function-calling-with-openai.ts",
+    "license": "MIT",
+    "dependencies": {
+        "aiconfig": "^1.1.5"
+    },
+    "devDependencies": {
+        "@types/node": "^20.9.0",
+        "openai": "^4.11.1",
+        "ts-node": "^10.9.1",
+        "typescript": "^5.2.2"
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,7 +249,7 @@ agentkeepalive@^4.2.1:
   dependencies:
     humanize-ms "^1.2.1"
 
-aiconfig@^1.0.0:
+aiconfig@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/aiconfig/-/aiconfig-1.1.5.tgz#9bc9a608f0b6e4dfda2fefc4da4a97feb0ea45d7"
   integrity sha512-b/UbUE504w+5wc90JhvJd/f0lnolbwkcVcK2VuP2+mv1ryBmNW71AxDanf1v+sh8iuRkhPH7pShkUcvncVUxSA==


### PR DESCRIPTION
[bug fix] parse out function argument from json

function call args are a serialized json object with named arguments.
Need to parse it out to pass the actual value into the function.

Tested by printing out the result of the function call before and after this change.

Before, since the argument is wrong, it gets no matches and you get empty list.
Now you get a book record as expected.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/CircleCI-Public/circleci-lastmile-ai/pull/2).
* #5
* #4
* #3
* __->__ #2