### PR TITLE
squash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 
 # Ignore built ts files
 dist/**/*
+
+
+__pycache__

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jonathanlastmileai @michael-webster

--- a/app.py
+++ b/app.py
@@ -1,85 +1,17 @@
 import asyncio
-import json
 import sys
-from typing import List
+from typing import List, cast
 
 from aiconfig import AIConfigRuntime
-from pydantic import BaseModel
+from aiconfig.schema import FunctionCallData
 
-
-class Book(BaseModel):
-    id: str
-    name: str
-    genre: str
-    description: str
-
-
-BOOKS_DB: List[Book] = [
-    Book(
-        id="a1",
-        name="To Kill a Mockingbird",
-        genre="historical",
-        description='Compassionate, dramatic, and deeply moving, "To Kill A Mockingbird" takes readers to the roots of human behavior - to innocence and experience, kindness and cruelty, love and hatred, humor and pathos. Now with over 18 million copies in print and translated into forty languages, this regional story by a young Alabama woman claims universal appeal. Harper Lee always considered her book to be a simple love story. Today it is regarded as a masterpiece of American literature.',
-    ),
-    Book(
-        id="a2",
-        name="All the Light We Cannot See",
-        genre="historical",
-        description="In a mining town in Germany, Werner Pfennig, an orphan, grows up with his younger sister, enchanted by a crude radio they find that brings them news and stories from places they have never seen or imagined. Werner becomes an expert at building and fixing these crucial new instruments and is enlisted to use his talent to track down the resistance. Deftly interweaving the lives of Marie-Laure and Werner, Doerr illuminates the ways, against all odds, people try to be good to one another.",
-    ),
-    Book(
-        id="a3",
-        name="Where the Crawdads Sing",
-        genre="historical",
-        description="For years, rumors of the “Marsh Girl” haunted Barkley Cove, a quiet fishing village. Kya Clark is barefoot and wild; unfit for polite society. So in late 1969, when the popular Chase Andrews is found dead, locals immediately suspect her.\n\nBut Kya is not what they say. A born naturalist with just one day of school, she takes life's lessons from the land, learning the real ways of the world from the dishonest signals of fireflies. But while she has the skills to live in solitude forever, the time comes when she yearns to be touched and loved. Drawn to two young men from town, who are each intrigued by her wild beauty, Kya opens herself to a new and startling world—until the unthinkable happens.",
-    ),
-]
-
-
-def list_by_genre(genre: str) -> List[Book]:
-    return [book for book in BOOKS_DB if book.genre == genre]
-
-
-def search(name: str) -> List[Book]:
-    return [book for book in BOOKS_DB if book.name == name]
-
-
-def get(id: str) -> Book | None:
-    for book in BOOKS_DB:
-        if book.id == id:
-            return book
-    return None
-
-
-def call_function(name: str, args: str) -> Book | None | List[Book]:
-    print(f"Calling function {name} with args {args}")
-    args_dict = json.loads(args)
-    match name:
-        case "list":
-            return list_by_genre(args_dict["genre"])
-        case "search":
-            return search(args_dict["name"])
-        case "get":
-            return get(args_dict["id"])
-        case _:
-            raise ValueError(f"Unknown function: {name}")
-
-
-def _serialize_book_data_to_text(book_data: Book | List[Book]) -> str:
-    def _serialize_one_book_to_text(book: Book) -> str:
-        return book.model_dump_json()
-
-    match book_data:
-        case list(books):
-            return "\n".join([_serialize_one_book_to_text(book) for book in books])
-        case Book():
-            return _serialize_one_book_to_text(book_data)
+from book_db import Book, call_function
 
 
 async def main(argv: list[str]) -> int:
     try:
-        user_query = sys.argv[1]
-        text_response = await _get_app_response(user_query)
+        user_query = argv[1]
+        text_response = await get_app_response(user_query)
         print("\n\nResponse:\n")
         print(text_response)
         return 0
@@ -91,14 +23,41 @@ async def main(argv: list[str]) -> int:
         return 1
 
 
-async def _get_app_response(user_query: str) -> str:
+def _serialize_book_data_to_text(book_data: Book | List[Book] | None) -> str:
+    def _serialize_one_book_to_text(book: Book) -> str:
+        return book.model_dump_json()
+
+    match book_data:
+        case list(books):
+            return "\n".join([_serialize_one_book_to_text(book) for book in books])
+        case Book():
+            return _serialize_one_book_to_text(book_data)
+        case None:
+            return "No books found"
+
+
+async def generate_response_from_data(
+    aiconfig: AIConfigRuntime, user_query: str, serialized_book_data: str
+) -> str:
+    params_for_get_text_response = dict(
+        user_query=user_query, function_output_as_text=serialized_book_data
+    )
+
+    print("Params for get_text_response:", params_for_get_text_response)
+    return await aiconfig.run_and_get_output_text(  # type: ignore[fixme]
+        "function_output_to_text_response", params_for_get_text_response
+    )
+
+
+async def get_app_response(user_query: str) -> str:
     print(f"User query: {user_query}")
     aiconfig = AIConfigRuntime.load("book_db_function_calling.aiconfig.json")
     user_input_params = dict(the_query=user_query)
-    function_call_response = (
-        (await aiconfig.run("user_query_to_function_call", user_input_params))[0]
+    function_call_response: FunctionCallData = cast(
+        FunctionCallData,
+        (await aiconfig.run("user_query_to_function_call", user_input_params))[0]  # type: ignore[union-attr]
         .data.value[0]
-        .function
+        .function,
     )
     print(
         f"Function call response: {function_call_response}, type: {type(function_call_response)}"
@@ -108,13 +67,8 @@ async def _get_app_response(user_query: str) -> str:
     )
     print(f"Function output: {function_output}")
 
-    function_output_as_text = _serialize_book_data_to_text(function_output)
-    qa_input = f"Question: {user_query}\n\nData: {function_output_as_text}\n\n"
-    # print(f"Function output as text: {function_output_as_text}")
-    function_output_params = dict(qa_input=qa_input)
-    return await aiconfig.run_and_get_output_text(
-        "function_output_to_text_response", function_output_params
-    )
+    serialized_book_data = _serialize_book_data_to_text(function_output)
+    return await generate_response_from_data(aiconfig, user_query, serialized_book_data)
 
 
 if __name__ == "__main__":

--- a/book_db.py
+++ b/book_db.py
@@ -1,0 +1,67 @@
+import json
+
+from pydantic import BaseModel
+
+
+class Book(BaseModel):
+    id: str
+    name: str
+    genre: str
+    description: str
+
+
+BOOKS_DB: list[Book] = [
+    Book(
+        id="a1",
+        name="To Kill a Mockingbird",
+        genre="historical",
+        description='Compassionate, dramatic, and deeply moving, "To Kill A Mockingbird" takes readers to the roots of human behavior - to innocence and experience, kindness and cruelty, love and hatred, humor and pathos. Now with over 18 million copies in print and translated into forty languages, this regional story by a young Alabama woman claims universal appeal. Harper Lee always considered her book to be a simple love story. Today it is regarded as a masterpiece of American literature.',
+    ),
+    Book(
+        id="a2",
+        name="All the Light We Cannot See",
+        genre="historical",
+        description="In a mining town in Germany, Werner Pfennig, an orphan, grows up with his younger sister, enchanted by a crude radio they find that brings them news and stories from places they have never seen or imagined. Werner becomes an expert at building and fixing these crucial new instruments and is enlisted to use his talent to track down the resistance. Deftly interweaving the lives of Marie-Laure and Werner, Doerr illuminates the ways, against all odds, people try to be good to one another.",
+    ),
+    Book(
+        id="a3",
+        name="Where the Crawdads Sing",
+        genre="historical",
+        description="For years, rumors of the “Marsh Girl” haunted Barkley Cove, a quiet fishing village. Kya Clark is barefoot and wild; unfit for polite society. So in late 1969, when the popular Chase Andrews is found dead, locals immediately suspect her.\n\nBut Kya is not what they say. A born naturalist with just one day of school, she takes life's lessons from the land, learning the real ways of the world from the dishonest signals of fireflies. But while she has the skills to live in solitude forever, the time comes when she yearns to be touched and loved. Drawn to two young men from town, who are each intrigued by her wild beauty, Kya opens herself to a new and startling world—until the unthinkable happens.",
+    ),
+    Book(
+        id="a4",
+        name="1984",
+        genre="dystopian",
+        description="Among the seminal texts of the 20th century, Nineteen Eighty-Four is a rare work that grows more haunting as its futuristic purgatory becomes more real. Published in 1949, the book offers political satirist George Orwell's nightmarish vision of a totalitarian, bureaucratic world and one poor stiff's attempt to find individuality. The brilliance of the novel is Orwell's prescience of modern life—the ubiquity of television, the distortion of the language—and his ability to construct such a thorough version of hell.",
+    ),
+]
+
+
+def list_by_genre(genre: str) -> list[Book]:
+    return [book for book in BOOKS_DB if book.genre == genre]
+
+
+def search(name: str) -> list[Book]:
+    return [book for book in BOOKS_DB if book.name == name]
+
+
+def get(id: str) -> Book | None:
+    for book in BOOKS_DB:
+        if book.id == id:
+            return book
+    return None
+
+
+def call_function(name: str, args: str) -> Book | None | list[Book]:
+    print(f"Calling function {name} with args {args}")
+    args_dict = json.loads(args)
+    match name:
+        case "list":
+            return list_by_genre(args_dict["genre"])
+        case "search":
+            return search(args_dict["name"])
+        case "get":
+            return get(args_dict["id"])
+        case _:
+            raise ValueError(f"Unknown function: {name}")

--- a/book_db_function_calling.aiconfig.json
+++ b/book_db_function_calling.aiconfig.json
@@ -5,17 +5,6 @@
   "metadata": {},
   "prompts": [
     {
-      "name": "function_output_to_text_response",
-      "input": "{{qa_input}}",
-      "metadata": {
-        "model": {
-          "name": "gpt-3.5-turbo"
-        }
-      },
-      "parameters": {},
-      "remember_chat_context": false
-    },
-    {
       "name": "user_query_to_function_call",
       "input": "{{the_query}}",
       "metadata": {
@@ -72,6 +61,21 @@
               "role": "system",
               "content": "Please use our book database, which you can access using functions to answer the following questions."
             }
+          }
+        },
+        "parameters": {},
+        "remember_chat_context": false
+      }
+    },
+    {
+      "name": "function_output_to_text_response",
+      "input": "Question: {{user_query}}\n\nData: {{function_output_as_text}}\n\n",
+      "metadata": {
+        "model": {
+          "name": "gpt-3.5-turbo",
+          "settings": {
+            "model": "gpt-3.5-turbo",
+            "temperature": 0
           }
         },
         "parameters": {},

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,9 @@
+{
+  "typeCheckingMode": "strict",
+  "include": ["**"],
+  "exclude": [],
+  "ignore": [],
+  "venv": "aiconfig",
+  "pythonVersion": "3.10",
+  "reportMissingTypeStubs": false
+}

--- a/test_app.py
+++ b/test_app.py
@@ -1,23 +1,27 @@
-import asyncio
-from functools import partial
 import json
+from functools import partial
+from typing import Any
+
 import pandas as pd
-import sys
-
-
+import pytest
+from aiconfig import AIConfigRuntime
 from aiconfig.eval.api import (
-    run_test_suite_with_inputs,
     TestSuiteWithInputsSettings,
+    common,
+    metrics,
+    run_test_suite_with_inputs,
 )
 
-from aiconfig.eval.api import metrics, common
-import pytest
+from app import generate_response_from_data, get_app_response
+from book_db import get, list_by_genre, search
 
 pd.set_option("display.max_colwidth", None)
 pd.set_option("display.max_columns", None)
 
+JSON = dict[str, Any]
 
-async def _correct_fn(datum: str, expected: str) -> bool:
+
+async def _correct_fn(datum: str, expected: JSON) -> bool:
     output_loaded = json.loads(datum)["value"][0]["function"]
     output_loaded["arguments"] = json.loads(output_loaded["arguments"])
 
@@ -29,7 +33,7 @@ async def _correct_fn(datum: str, expected: str) -> bool:
     return output_loaded_normalized == expected_normalized
 
 
-def correct_function(expected: str):
+def correct_function(expected: JSON):
     return metrics.Metric(
         evaluation_fn=partial(_correct_fn, expected=expected),
         metric_metadata=common.EvaluationMetricMetadata(
@@ -44,7 +48,7 @@ def correct_function(expected: str):
 
 @pytest.mark.asyncio
 async def test_function_accuracy():
-    test_pairs = [
+    test_pairs: list[tuple[str, JSON]] = [
         (
             "ID isbn123",
             #
@@ -72,14 +76,14 @@ async def test_function_accuracy():
     )
 
     accuracy = (
-        df_result.query("metric_name=='correct_function'").value.fillna(False).mean()
+        df_result.query("metric_name=='correct_function'").value.fillna(False).mean()  # type: ignore[pandas]
     )
 
     is_acceptable_accuracy = accuracy > 0.9
 
     print(
         "Result dataframe:\n",
-        df_result.set_index(["input", "aiconfig_output", "metric_name"]).value.unstack(
+        df_result.set_index(["input", "aiconfig_output", "metric_name"]).value.unstack(  # type: ignore[pandas]
             "metric_name"
         ),
     )
@@ -87,3 +91,63 @@ async def test_function_accuracy():
     print(f"Correct function accuracy: {accuracy}")
 
     assert is_acceptable_accuracy, f"Low accuracy: {accuracy}"
+
+
+def test_book_db_api():
+    query_result_1 = search("harry potter")
+    assert query_result_1 == []
+
+    query_result_2 = get("a2")
+    assert query_result_2 is not None
+    assert query_result_2.name == "All the Light We Cannot See"
+
+    query_result_3 = [book.name for book in list_by_genre("dystopian")]
+
+    assert query_result_3 == ["1984"]
+
+
+@pytest.mark.asyncio
+async def test_generate_correctness_1():
+    aiconfig = AIConfigRuntime.load("book_db_function_calling.aiconfig.json")
+    response1 = await generate_response_from_data(
+        aiconfig,
+        "how widely-read is 'To Kill a Mockingbird'?",
+        '{"id":"a1","name":"To Kill a Mockingbird","genre":"historical","description":"Compassionate, dramatic, and deeply moving, \\"To Kill A Mockingbird\\" takes readers to the roots of human behavior - to innocence and experience, kindness and cruelty, love and hatred, humor and pathos. Now with over 18 million copies in print and translated into forty languages, this regional story by a young Alabama woman claims universal appeal. Harper Lee always considered her book to be a simple love story. Today it is regarded as a masterpiece of American literature."}',
+    )
+    print(f"{response1=}")
+    assert "18 million" in response1.lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_correctness_2():
+    aiconfig = AIConfigRuntime.load("book_db_function_calling.aiconfig.json")
+    response2 = await generate_response_from_data(
+        aiconfig,
+        "whats in our historical collection?",
+        '{"id":"a1","name":"To Kill a Mockingbird","genre":"historical","description":"Compassionate, dramatic, and deeply moving, \\"To Kill A Mockingbird\\" takes readers to the roots of human behavior - to innocence and experience, kindness and cruelty, love and hatred, humor and pathos. Now with over 18 million copies in print and translated into forty languages, this regional story by a young Alabama woman claims universal appeal. Harper Lee always considered her book to be a simple love story. Today it is regarded as a masterpiece of American literature."}\n{"id":"a2","name":"All the Light We Cannot See","genre":"historical","description":"In a mining town in Germany, Werner Pfennig, an orphan, grows up with his younger sister, enchanted by a crude radio they find that brings them news and stories from places they have never seen or imagined. Werner becomes an expert at building and fixing these crucial new instruments and is enlisted to use his talent to track down the resistance. Deftly interweaving the lives of Marie-Laure and Werner, Doerr illuminates the ways, against all odds, people try to be good to one another."}\n{"id":"a3","name":"Where the Crawdads Sing","genre":"historical","description":"For years, rumors of the “Marsh Girl” haunted Barkley Cove, a quiet fishing village. Kya Clark is barefoot and wild; unfit for polite society. So in late 1969, when the popular Chase Andrews is found dead, locals immediately suspect her.\\n\\nBut Kya is not what they say. A born naturalist with just one day of school, she takes life\'s lessons from the land, learning the real ways of the world from the dishonest signals of fireflies. But while she has the skills to live in solitude forever, the time comes when she yearns to be touched and loved. Drawn to two young men from town, who are each intrigued by her wild beauty, Kya opens herself to a new and startling world—until the unthinkable happens."}',
+    )
+    for historical_book_name in [
+        "All the Light We Cannot See",
+        "To Kill a Mockingbird",
+        "Where the Crawdads Sing",
+    ]:
+        assert historical_book_name in response2
+
+
+@pytest.mark.asyncio
+async def test_e2e_correctness_1():
+    response1 = await get_app_response("how widely-read is 'To Kill a Mockingbird'?")
+    print(f"{response1=}")
+    assert "18 million" in response1.lower()
+
+
+@pytest.mark.asyncio
+async def test_e2e_correctness_2():
+    # This corresponds to what we expect for upstream input "whats in our historical collection?"
+    response2 = await get_app_response("whats in our historical collection?")
+    for historical_book_name in [
+        "All the Light We Cannot See",
+        "To Kill a Mockingbird",
+        "Where the Crawdads Sing",
+    ]:
+        assert historical_book_name in response2


### PR DESCRIPTION
squash
- ignore pycache
- deowners for auto review
- pyright config
  Adding this config for pyright to check almost everything it can.
  I know this is out of scope for LLM dev / genai, but I've found this pretty optimal for preventing bugs without adding noise.)
  It would be great to set up CI/CD involving pyright as well, ideally at some level of granularity.
  e.g. maybe certain files can be merge-blocking, or we could have a pyright correctness coverage regression test.

- clean up code structure
- add another book with a different genre
- Write tests
- fix aiconfig test
- swap the prompt order so it's the same as program execution order
